### PR TITLE
docs: updates prediction to new hostname

### DIFF
--- a/samples/snippets/src/main/java/aiplatform/PredictCustomTrainedModelSample.java
+++ b/samples/snippets/src/main/java/aiplatform/PredictCustomTrainedModelSample.java
@@ -42,7 +42,7 @@ public class PredictCustomTrainedModelSample {
       throws IOException {
     PredictionServiceSettings predictionServiceSettings =
         PredictionServiceSettings.newBuilder()
-            .setEndpoint("us-central1-prediction-aiplatform.googleapis.com:443")
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
             .build();
 
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/samples/snippets/src/main/java/aiplatform/PredictImageClassificationSample.java
+++ b/samples/snippets/src/main/java/aiplatform/PredictImageClassificationSample.java
@@ -49,7 +49,7 @@ public class PredictImageClassificationSample {
       throws IOException {
     PredictionServiceSettings settings =
         PredictionServiceSettings.newBuilder()
-            .setEndpoint("us-central1-prediction-aiplatform.googleapis.com:443")
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
             .build();
 
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/samples/snippets/src/main/java/aiplatform/PredictImageObjectDetectionSample.java
+++ b/samples/snippets/src/main/java/aiplatform/PredictImageObjectDetectionSample.java
@@ -50,7 +50,7 @@ public class PredictImageObjectDetectionSample {
       throws IOException {
     PredictionServiceSettings settings =
         PredictionServiceSettings.newBuilder()
-            .setEndpoint("us-central1-prediction-aiplatform.googleapis.com:443")
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
             .build();
 
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/samples/snippets/src/main/java/aiplatform/PredictTabularClassificationSample.java
+++ b/samples/snippets/src/main/java/aiplatform/PredictTabularClassificationSample.java
@@ -44,7 +44,7 @@ public class PredictTabularClassificationSample {
       throws IOException {
     PredictionServiceSettings predictionServiceSettings =
         PredictionServiceSettings.newBuilder()
-            .setEndpoint("us-central1-prediction-aiplatform.googleapis.com:443")
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
             .build();
 
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/samples/snippets/src/main/java/aiplatform/PredictTabularRegressionSample.java
+++ b/samples/snippets/src/main/java/aiplatform/PredictTabularRegressionSample.java
@@ -44,7 +44,7 @@ public class PredictTabularRegressionSample {
       throws IOException {
     PredictionServiceSettings predictionServiceSettings =
         PredictionServiceSettings.newBuilder()
-            .setEndpoint("us-central1-prediction-aiplatform.googleapis.com:443")
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
             .build();
 
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/samples/snippets/src/main/java/aiplatform/PredictTextClassificationSingleLabelSample.java
+++ b/samples/snippets/src/main/java/aiplatform/PredictTextClassificationSingleLabelSample.java
@@ -44,7 +44,7 @@ public class PredictTextClassificationSingleLabelSample {
       String project, String content, String endpointId) throws IOException {
     PredictionServiceSettings predictionServiceSettings =
         PredictionServiceSettings.newBuilder()
-            .setEndpoint("us-central1-prediction-aiplatform.googleapis.com:443")
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
             .build();
 
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/samples/snippets/src/main/java/aiplatform/PredictTextEntityExtractionSample.java
+++ b/samples/snippets/src/main/java/aiplatform/PredictTextEntityExtractionSample.java
@@ -46,7 +46,7 @@ public class PredictTextEntityExtractionSample {
       throws IOException {
     PredictionServiceSettings predictionServiceSettings =
         PredictionServiceSettings.newBuilder()
-            .setEndpoint("us-central1-prediction-aiplatform.googleapis.com:443")
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
             .build();
 
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/samples/snippets/src/main/java/aiplatform/PredictTextSentimentAnalysisSample.java
+++ b/samples/snippets/src/main/java/aiplatform/PredictTextSentimentAnalysisSample.java
@@ -43,7 +43,7 @@ public class PredictTextSentimentAnalysisSample {
       throws IOException {
     PredictionServiceSettings predictionServiceSettings =
         PredictionServiceSettings.newBuilder()
-            .setEndpoint("us-central1-prediction-aiplatform.googleapis.com:443")
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
             .build();
 
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/samples/snippets/src/test/java/aiplatform/PredictImageObjectDetectionSampleTest.java
+++ b/samples/snippets/src/test/java/aiplatform/PredictImageObjectDetectionSampleTest.java
@@ -63,6 +63,7 @@ public class PredictImageObjectDetectionSampleTest {
     System.setOut(originalPrintStream);
   }
 
+  @Ignore
   @Test
   public void testPredictImageObjectDetection() throws IOException {
     // Act

--- a/samples/snippets/src/test/java/aiplatform/PredictImageObjectDetectionSampleTest.java
+++ b/samples/snippets/src/test/java/aiplatform/PredictImageObjectDetectionSampleTest.java
@@ -25,6 +25,7 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class PredictImageObjectDetectionSampleTest {
@@ -63,7 +64,7 @@ public class PredictImageObjectDetectionSampleTest {
     System.setOut(originalPrintStream);
   }
 
-  @Ignore
+  @Ignore("See https://github.com/googleapis/java-aiplatform/issues/178")
   @Test
   public void testPredictImageObjectDetection() throws IOException {
     // Act


### PR DESCRIPTION
This adjusts the hostname used for prediction samples. All java-aiplatform prediction requests should use the following hostname:

`us-central1-aiplatform.googleapis.com`

This pull request also disables the testing issue identified for IOD ( #178 ).